### PR TITLE
Add JDK 21 setup and update dependencies

### DIFF
--- a/.github/workflows/assignee.yml
+++ b/.github/workflows/assignee.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: 🔄 Auto Assign
         uses: actions-ecosystem/action-add-assignees@v1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
         language: [ java ]
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: ♻️ Cache Maven deps
         uses: actions/cache@v5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: ♻️ Cache Maven deps
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,12 @@ jobs:
       - name: 📥 Checkout code
         uses: actions/checkout@v7
 
+      - name: Setup JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
       - name: ♻️ Cache Maven deps
         uses: actions/cache@v6
         with:
@@ -36,6 +42,9 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
+          config: |
+            java:
+              version: 21
 
       - name: 🔨 Build project
         run: ./mvnw compile -B

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🧾 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: 🛠️ Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout PR code (head)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
 
       - id: release
         name: 🔄 Run release-please
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           token: '${{ secrets.RELEASE_PLEASE_TOKEN }}'
           config-file: .github/release-please-config.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - id: checkout
         name: 📥 Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: release
         name: 🔄 Run release-please

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>io.github.justedlev.msrvs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
 
-        <spring-cloud.version>2025.1.1</spring-cloud.version>
+        <spring-cloud.version>2025.1.2</spring-cloud.version>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.6</version>
+        <version>4.1.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>io.github.justedlev.msrvs</groupId>


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary
This pull request introduces the setup for JDK 21 in the CodeQL analysis configuration and updates multiple project dependencies to their latest stable versions, ensuring compatibility and security improvements.

## 🔍 Changes
- Configured CodeQL analysis to include JDK 21.
- Updated the following GitHub Actions dependencies:
  - `actions/cache` to v6.
  - `actions/checkout` to v7.
  - `googleapis/release-please-action` to v5.
- Updated Spring-related dependencies:
  - `org.springframework.boot:spring-boot-starter-parent` from v4.0.5 to v4.1.0 (minor and patch releases).
  - `org.springframework.cloud:spring-cloud-dependencies` from v2025.1.1 to v2025.1.2.

## :package: Type of Change

- [ ] :bug: Bug fix — Fixes an issue or defect
- [ ] :sparkles: New feature — Adds new functionality
- [ ] :recycle: Refactor — Code changes without affecting functionality
- [ ] :memo: Documentation — Updates to docs only
- [ ] :white_check_mark: Tests — Adds or updates tests
- [x] :arrow_up: Dependency update — Updates project dependencies
- [x] :wrench: Configuration or build system
- [ ] :rocket: Performance improvement
- [ ] :construction: Other (please describe below)

## :link: Related Issues

Closes #...

Fixes #...

## 🧪 Testing
To test these changes:
1. Validate the updated dependencies install and function without issues.
2. Verify CodeQL analysis completes successfully using JDK 21.

## :white_check_mark: Checklist

- [x] Code builds correctly ✅
- [ ] Tests have been added or updated 🧪
- [ ] Docs were updated if necessary 📝
- [x] Follows style guidelines 🎨